### PR TITLE
Not found SKUs message logic added

### DIFF
--- a/messages/context.json
+++ b/messages/context.json
@@ -179,5 +179,8 @@
   "store/affiliate.register.errorURLInUse": "Affiliate url is already in use",
   "store/affiliate.register.errorAffiliateExists": "Affiliate already exists, email is already in use",
   "store/affiliate.register.errorAffiliateNotFound": "Affiliate not found, there is no affiliate with this email",
-  "store/affiliate.register.errorEmailAlreadyInUse": "The email is already being used by some other affiliate"
+  "store/affiliate.register.errorEmailAlreadyInUse": "The email is already being used by some other affiliate",
+  "admin/affiliate.commissionWarning": "The last spreadsheet has SKUs not found in the store, this will not cancel the process, it will just not add the specific not found value",
+  "admin/affiliate.commissionSuccess": "All spreadsheet SKUs that have been verified so far have been found in the store",
+  "admin/affiliate.verifySKUs": "Verify SKUs"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -178,5 +178,8 @@
   "store/affiliate.register.errorURLInUse": "Affiliate url is already in use",
   "store/affiliate.register.errorAffiliateExists": "Affiliate already exists, email is already in use",
   "store/affiliate.register.errorAffiliateNotFound": "Affiliate not found, there is no affiliate with this email",
-  "store/affiliate.register.errorEmailAlreadyInUse": "The email is already being used by some other affiliate"
+  "store/affiliate.register.errorEmailAlreadyInUse": "The email is already being used by some other affiliate",
+  "admin/affiliate.commissionWarning": "The last spreadsheet has SKUs not found in the store, this will not cancel the process, it will just not add the specific not found value",
+  "admin/affiliate.commissionSuccess": "All spreadsheet SKUs that have been verified so far have been found in the store",
+  "admin/affiliate.verifySKUs": "Verify SKUs"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -178,5 +178,8 @@
   "store/affiliate.register.errorURLInUse": "Essa URL de Afiliado já está em uso",
   "store/affiliate.register.errorAffiliateExists": "O Afiliado já existe, esse email já está em uso",
   "store/affiliate.register.errorAffiliateNotFound": "Afiliado não encontrado, esse email não está sendo usado por nenhum afiliado",
-  "store/affiliate.register.errorEmailAlreadyInUse": "Esse email já está em uso por outro afiliado"
+  "store/affiliate.register.errorEmailAlreadyInUse": "Esse email já está em uso por outro afiliado",
+  "admin/affiliate.commissionWarning": "A última planilha possui SKUs não encontrados na loja, isso não cancelará o processo, apenas não adicionará o valor específico não encontrado",
+  "admin/affiliate.commissionSuccess": "Todos os SKUs da planilha que foram verificados até agora foram encontrados na loja",
+  "admin/affiliate.verifySKUs": "Verificar SKUs"
 }

--- a/react/components/admin/commissions/CommissionsNotFound.tsx
+++ b/react/components/admin/commissions/CommissionsNotFound.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Alert } from '@vtex/admin-ui'
+import { useIntl } from 'react-intl'
+
+import { messages } from '../../../utils/messages'
+
+interface CommissionsNotFoundProps {
+  notFound: boolean
+}
+
+function CommissionsNotFound(props: CommissionsNotFoundProps) {
+  const { notFound } = props
+  const intl = useIntl()
+
+  return (
+    <>
+      {notFound === true ? (
+        <Alert variant="warning">
+          {intl.formatMessage(messages.affiliateCommissionWarning)}
+        </Alert>
+      ) : (
+        <Alert variant="positive">
+          {intl.formatMessage(messages.affiliateCommissionSuccess)}
+        </Alert>
+      )}
+    </>
+  )
+}
+
+export default CommissionsNotFound

--- a/react/graphql/deleteNotFoundSKUs.graphql
+++ b/react/graphql/deleteNotFoundSKUs.graphql
@@ -1,0 +1,3 @@
+mutation setNotFound {
+  deleteNotFounds
+}

--- a/react/graphql/getNotFoundSKUs.graphql
+++ b/react/graphql/getNotFoundSKUs.graphql
@@ -1,0 +1,3 @@
+query getNotFoundSKUs {
+  getNotFoundCommissions
+}

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -158,6 +158,15 @@ export const messages = defineMessages({
   },
   noLastFileLabel: { id: 'admin/import.no.last.file.label' },
   editAffiliateApproveStatusTitle: { id: 'admin/edit.affiliate.approve.title' },
+  affiliateCommissionWarning: {
+    id: 'admin/affiliate.commissionWarning',
+  },
+  affiliateCommissionSuccess: {
+    id: 'admin/affiliate.commissionSuccess',
+  },
+  affiliateVerifySKUs: {
+    id: 'admin/affiliate.verifySKUs',
+  },
 })
 
 export const storeMessages = defineMessages({


### PR DESCRIPTION
#### What is the purpose of this pull request?

Based on the last affiliates-commission-service PR, we are adding two new graphQL operations to be used by the front end.
When a client uploads a new commissions spreadsheet, the back end will return if some of the IDs were not found by our catalog API, and by clicking on verifying the SKUs the client will be able to know if some error happened

#### What problem is this solving?

Better user experience

#### How to test it?

Accessing the link below and uploading some spreadsheets
https://commissionstest--bibiafiliados.myvtex.com/admin/affiliates-commissions

#### Screenshots or example usage

<img width="1493" alt="commisionsWarning" src="https://user-images.githubusercontent.com/53904010/200675746-fa84c4a1-58d6-4dda-96d2-2bea8cf4d666.png">

<img width="1485" alt="commisionsSuccess" src="https://user-images.githubusercontent.com/53904010/200675784-fc6337c7-238c-4e59-84bc-04760da13212.png">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/Qh4FSYVY3jvmeVjRur/giphy-downsized.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
