### PR TITLE
Feature / List Workspaces for deleting the schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2023-09-28
+
 ### Added
 
 - Schema client created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Schema client created
+
 ## [1.5.3] - 2023-05-04
 
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -13,6 +13,7 @@ type Query {
     filter: AffiliatesFilterInput
     sorting: AffliatesSortingInput
   ): [AffiliateScroll]!
+  getWorkspaces: [Workspaces]
 }
 
 type Mutation {

--- a/graphql/types/workspaces.graphql
+++ b/graphql/types/workspaces.graphql
@@ -1,0 +1,4 @@
+type Workspaces {
+  name: String
+  production: Boolean
+}

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,9 @@
     },
     {
       "name": "colossus-write-logs"
+    },
+    {
+      "name": "read-write-any-workspace"
     }
   ],
   "settingsSchema": {
@@ -100,9 +103,7 @@
   },
   "billingOptions": {
     "type": "free",
-    "availableCountries": [
-      "*"
-    ],
+    "availableCountries": ["*"],
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affiliates",
   "vendor": "vtex",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "title": "Affiliates",
   "description": "App that adds support for affiliates on IO stores",
   "mustUpdateAt": "2018-01-04",
@@ -103,7 +103,9 @@
   },
   "billingOptions": {
     "type": "free",
-    "availableCountries": ["*"],
+    "availableCountries": [
+      "*"
+    ],
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     }

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -4,6 +4,7 @@ import type { Affiliates, UserAffiliation } from 'vtex.affiliates'
 
 import AuthenticationClient from './authenticationClient'
 import CheckoutExtended from './checkout'
+import SchemasClient from './schemas'
 
 export class Clients extends IOClients {
   public get affiliates() {
@@ -23,5 +24,9 @@ export class Clients extends IOClients {
 
   public get authentication() {
     return this.getOrSet('authentication', AuthenticationClient)
+  }
+
+  public get schemas() {
+    return this.getOrSet('schemas', SchemasClient)
   }
 }

--- a/node/clients/schemas.ts
+++ b/node/clients/schemas.ts
@@ -1,0 +1,33 @@
+import type { InstanceOptions, IOContext, RequestConfig } from '@vtex/api'
+import { ExternalClient } from '@vtex/api'
+
+const routes = {
+  schemas: (dataEntity: string) => `/dataentities/${dataEntity}/schemas`,
+  delete: (dataEntity: string, schemaName: string) =>
+    `dataentities/${dataEntity}/schemas/${schemaName}`,
+}
+
+export default class SchemasClient extends ExternalClient {
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(`http://${context.account}.myvtex.com/api`, context, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        VtexIdclientAutCookie: context.authToken,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
+
+  public getSchemas(dataEntity: string, config?: RequestConfig): Promise<any> {
+    return this.http.get(routes.schemas(dataEntity), config)
+  }
+
+  public deleteSchemas(
+    dataEntity: string,
+    schemaName: string,
+    config?: RequestConfig
+  ): Promise<any> {
+    return this.http.delete(routes.delete(dataEntity, schemaName), config)
+  }
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -35,6 +35,7 @@ import { getAffiliate } from './resolvers/getAffiliate'
 import { fieldResolvers } from './resolvers/fieldResolvers'
 import { getAffiliateByEmail } from './resolvers/getAffiliateByEmail'
 import { getWorkspaces } from './resolvers/getWorkspaces'
+import { getSchemas } from './middlewares/getSchemas'
 
 const TIMEOUT_MS = 1000
 
@@ -90,6 +91,9 @@ declare global {
 export default new Service({
   clients,
   routes: {
+    schemas: method({
+      GET: [getSchemas],
+    }),
     affiliate: method({
       POST: [authenticateRequest, validateCreate, createAffiliate],
       PATCH: [authenticateRequest, validateUpdate, updateAffiliate],

--- a/node/index.ts
+++ b/node/index.ts
@@ -34,6 +34,7 @@ import { updateAffiliate as updateAffiliateResolver } from './resolvers/updateAf
 import { getAffiliate } from './resolvers/getAffiliate'
 import { fieldResolvers } from './resolvers/fieldResolvers'
 import { getAffiliateByEmail } from './resolvers/getAffiliateByEmail'
+import { getWorkspaces } from './resolvers/getWorkspaces'
 
 const TIMEOUT_MS = 1000
 
@@ -112,6 +113,7 @@ export default new Service({
         getAffiliate,
         getAffiliateByEmail,
         getAffiliatesScroll,
+        getWorkspaces,
       },
       Mutation: {
         addAffiliate,

--- a/node/middlewares/getSchemas.ts
+++ b/node/middlewares/getSchemas.ts
@@ -1,0 +1,22 @@
+export async function getSchemas(ctx: Context, next: () => Promise<unknown>) {
+  const {
+    clients: { schemas },
+    vtex: { logger },
+  } = ctx
+
+  try {
+    const schemaList = await schemas.getSchemas('vtex_affiliates_Affiliates')
+
+    console.info('testing', schemaList)
+    ctx.message = `Schema list retrieved`
+    ctx.status = 200
+  } catch (err) {
+    logger.error({
+      metric: 'get-affiliate-schema',
+      message: err.message,
+    })
+    throw new Error('Error getting affiliate schemas')
+  }
+
+  await next()
+}

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.21",
     "@vtex/test-tools": "^3.4.1",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.21",
+    "@vtex/api": "6.45.22",
     "@vtex/test-tools": "^3.4.1",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/package.json
+++ b/node/package.json
@@ -18,5 +18,5 @@
     "lint": "tsc --noEmit --pretty",
     "test": "vtex-test-tools test --collectCoverage"
   },
-  "version": "1.5.3"
+  "version": "1.6.0"
 }

--- a/node/resolvers/getWorkspaces.ts
+++ b/node/resolvers/getWorkspaces.ts
@@ -1,0 +1,8 @@
+import { ACCOUNT } from '@vtex/api'
+
+export const getWorkspaces = async (_: unknown, __: unknown, ctx: Context) => {
+  const { workspaces } = ctx.clients
+  const result = await workspaces.list(ACCOUNT)
+
+  return result
+}

--- a/node/resolvers/getWorkspaces.ts
+++ b/node/resolvers/getWorkspaces.ts
@@ -1,8 +1,6 @@
-import { ACCOUNT } from '@vtex/api'
-
 export const getWorkspaces = async (_: unknown, __: unknown, ctx: Context) => {
   const { workspaces } = ctx.clients
-  const result = await workspaces.list(ACCOUNT)
+  const result = await workspaces.list(ctx.vtex.account)
 
   return result
 }

--- a/node/service.json
+++ b/node/service.json
@@ -6,6 +6,10 @@
   "maxReplicas": 4,
   "workers": 1,
   "routes": {
+    "schemas": {
+      "path": "/_v/affiliateSchemas",
+      "public": true
+    },
     "affiliate": {
       "path": "/_v/affiliate",
       "public": true

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1658,10 +1658,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.21":
-  version "6.45.21"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.21.tgz#2f5ea4a14dfbf426f6fbad140caf23c89060b313"
-  integrity sha512-Yo4og5bSM1n5WSQ3u8nsqEHicvxdyOZX3uA0KtQHbS4frSeA4hcGRuupsFHQ13eZZGMy4OR4fJO7ZQfkj8qLhQ==
+"@vtex/api@6.45.22":
+  version "6.45.22"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
+  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1658,10 +1658,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.12":
-  version "6.45.12"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
-  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
+"@vtex/api@6.45.21":
+  version "6.45.21"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.21.tgz#2f5ea4a14dfbf426f6fbad140caf23c89060b313"
+  integrity sha512-Yo4og5bSM1n5WSQ3u8nsqEHicvxdyOZX3uA0KtQHbS4frSeA4hcGRuupsFHQ13eZZGMy4OR4fJO7ZQfkj8qLhQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -1681,7 +1681,7 @@
     fs-extra "^7.0.0"
     graphql "^14.5.8"
     graphql-tools "^4.0.6"
-    graphql-upload "^8.1.0"
+    graphql-upload "^13.0.0"
     jaeger-client "^3.18.0"
     js-base64 "^2.5.1"
     koa "^2.11.0"
@@ -1692,7 +1692,7 @@
     mime-types "^2.1.12"
     opentracing "^0.14.4"
     p-limit "^2.2.0"
-    prom-client "^12.0.0"
+    prom-client "^14.2.0"
     qs "^6.5.1"
     querystring "^0.2.0"
     ramda "^0.26.0"
@@ -3172,10 +3172,10 @@ fresh@~0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
-fs-capacitor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
-  integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
+fs-capacitor@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-6.2.0.tgz#fa79ac6576629163cb84561995602d8999afb7f5"
+  integrity sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -3296,15 +3296,15 @@ graphql-tools@^4.0.6:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql-upload@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"
-  integrity sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==
+graphql-upload@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-13.0.0.tgz#1a255b64d3cbf3c9f9171fa62a8fb0b9b59bb1d9"
+  integrity sha512-YKhx8m/uOtKu4Y1UzBFJhbBGJTlk7k4CydlUUiNrtxnwZv0WigbRHP+DVhRNKt7u7DXOtcKZeYJlGtnMXvreXA==
   dependencies:
     busboy "^0.3.1"
-    fs-capacitor "^2.0.4"
-    http-errors "^1.7.3"
-    object-path "^0.11.4"
+    fs-capacitor "^6.2.0"
+    http-errors "^1.8.1"
+    object-path "^0.11.8"
 
 graphql@^14.0.0, graphql@^14.5.8:
   version "14.7.0"
@@ -3449,7 +3449,7 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
-http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.7.3, http-errors@~1.8.0:
+http-errors@^1.3.1, http-errors@^1.6.3, http-errors@^1.8.1, http-errors@~1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
   integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
@@ -4799,7 +4799,7 @@ object-keys@^1.0.12, object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object-path@^0.11.4:
+object-path@^0.11.8:
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
   integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
@@ -5050,10 +5050,10 @@ process@^0.10.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.10.1.tgz#842457cc51cfed72dc775afeeafb8c6034372725"
   integrity sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
     tdigest "^0.1.1"
 
@@ -5709,7 +5709,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/admin/commissions/CommissionsTable.tsx
+++ b/react/components/admin/commissions/CommissionsTable.tsx
@@ -53,8 +53,8 @@ const CommissionsTable: FC = () => {
   const {
     culture: { locale },
   } = useRuntime()
+
   const view = useDataViewState()
-  
   const modal = useModalState()
   const showToast = useToast()
   const [selectedRow, setSelectedRow] = useState<TableColumns>()

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.affiliates",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "scripts": {
     "test": "vtex-test-tools test --collectCoverage"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

New resolver that list all workspaces on the current account installation.
This will be used to delete the schemas on all workspaces afterwards.

#### What problem is this solving?
- Update Schemas step

#### How to test it?
https://newaffiliates--sandboxbrdev.myvtex.com/admin/graphql-ide

#### Screenshots or example usage
<img width="1784" alt="image" src="https://github.com/vtex/affiliates/assets/53904010/2b65052c-4ab9-45ff-bc39-1aa6f89e38f6">

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/5dTChZbfNzptXLT5Wz/giphy.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
