### PR TITLE
Extended Master Data Class and Builder delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.7.1] - 2023-10-30
-
 ### Changed
 - Master Data Builder usage
 - New function that extends MD Client to use a specific schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.1] - 2023-10-30
+
 ### Changed
 - Master Data Builder usage
 - New function that extends MD Client to use a specific schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- GraphQL AddAffiliate query autenthication
+
 ### Changed
 - Master Data Builder usage
 - New function that extends MD Client to use a specific schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Master Data Builder usage
+- New function that extends MD Client to use a specific schema
+
 ## [1.7.0] - 2023-10-09
 
 ## [1.6.1] - 2023-10-09

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -7,7 +7,7 @@ type Query {
     filter: AffiliatesFilterInput
     sorting: AffliatesSortingInput
   ): AffiliatesPage! @checkAdminAccess
-  getAffiliate(affiliateId: ID!): Affiliate @checkAdminAccess
+  getAffiliate(affiliateId: ID!): Affiliate @checkUserAccess
   getAffiliateByEmail(email: String!): Affiliate
   getAffiliatesScroll(
     filter: AffiliatesFilterInput
@@ -16,7 +16,7 @@ type Query {
 }
 
 type Mutation {
-  addAffiliate(newAffiliate: NewAffiliateInput!): Affiliate! @checkAdminAccess
+  addAffiliate(newAffiliate: NewAffiliateInput!): Affiliate!
   updateAffiliate(
     affiliateId: String!
     updateAffiliate: UpdateAffiliateInput!

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,6 @@
     "node": "6.x",
     "docs": "0.x",
     "react": "3.x",
-    "masterdata": "1.x",
     "graphql": "1.x",
     "store": "0.x",
     "messages": "1.x",
@@ -97,9 +96,7 @@
   },
   "billingOptions": {
     "type": "free",
-    "availableCountries": [
-      "*"
-    ],
+    "availableCountries": ["*"],
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "affiliates",
   "vendor": "vtex",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "title": "Affiliates",
   "description": "App that adds support for affiliates on IO stores",
   "mustUpdateAt": "2018-01-04",
@@ -96,7 +96,9 @@
   },
   "billingOptions": {
     "type": "free",
-    "availableCountries": ["*"],
+    "availableCountries": [
+      "*"
+    ],
     "support": {
       "url": "https://support.vtex.com/hc/requests"
     }

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -6,16 +6,23 @@ import AuthenticationClient from './authenticationClient'
 import CheckoutExtended from './checkout'
 import IdentityClient from './IdentityClient'
 import VtexId from './vtexId'
+import { withCustomSchema } from '../utils/withCustomSchema'
 
 export class Clients extends IOClients {
   public get affiliates() {
-    return this.getOrSet('affiliates', masterDataFor<Affiliates>('affiliates'))
+    return this.getOrSet(
+      'affiliates',
+      withCustomSchema('1.7.0', masterDataFor<Affiliates>('affiliates'))
+    )
   }
 
   public get userAffiliation() {
     return this.getOrSet(
       'userAffiliation',
-      masterDataFor<UserAffiliation>('userAffiliation')
+      withCustomSchema(
+        '1.7.0',
+        masterDataFor<UserAffiliation>('userAffiliation')
+      )
     )
   }
 

--- a/node/clients/index.ts
+++ b/node/clients/index.ts
@@ -1,7 +1,7 @@
 import { IOClients } from '@vtex/api'
 import { masterDataFor } from '@vtex/clients'
-import type { Affiliates, UserAffiliation } from 'vtex.affiliates'
 
+import type { Affiliates, UserAffiliation } from '../typings/affiliates'
 import AuthenticationClient from './authenticationClient'
 import CheckoutExtended from './checkout'
 import IdentityClient from './IdentityClient'

--- a/node/middlewares/validateCreate.ts
+++ b/node/middlewares/validateCreate.ts
@@ -1,7 +1,6 @@
 import { json } from 'co-body'
-import type { Affiliates } from 'vtex.affiliates'
 
-import type { AffiliateInput } from '../typings/affiliates'
+import type { Affiliates, AffiliateInput } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 
 export async function validateCreate(

--- a/node/middlewares/validateUpdate.ts
+++ b/node/middlewares/validateUpdate.ts
@@ -1,7 +1,6 @@
 import { json } from 'co-body'
-import type { Affiliates } from 'vtex.affiliates'
 
-import type { AffiliateInput } from '../typings/affiliates'
+import type { Affiliates, AffiliateInput } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 
 export async function validateUpdate(

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.45.24",
     "@vtex/test-tools": "^3.4.1",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/package.json
+++ b/node/package.json
@@ -18,5 +18,5 @@
     "lint": "tsc --noEmit --pretty",
     "test": "vtex-test-tools test --collectCoverage"
   },
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/node/resolvers/addAffiliate.ts
+++ b/node/resolvers/addAffiliate.ts
@@ -1,6 +1,7 @@
-import type { Affiliates, MutationAddAffiliateArgs } from 'vtex.affiliates'
+import type { MutationAddAffiliateArgs } from 'vtex.affiliates'
 import CustomGraphQLError from '@vtex/api/lib/errors/customGraphQLError'
 
+import type { Affiliates } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 import type { Error } from './pushErrors'
 import { pushErrors } from './pushErrors'

--- a/node/resolvers/fieldResolvers.ts
+++ b/node/resolvers/fieldResolvers.ts
@@ -1,4 +1,4 @@
-import type { Affiliates } from 'vtex.affiliates'
+import type { Affiliates } from '../typings/affiliates'
 
 export const fieldResolvers = {
   Affiliate: {

--- a/node/resolvers/getAffiliateByEmail.ts
+++ b/node/resolvers/getAffiliateByEmail.ts
@@ -1,5 +1,4 @@
-import type { Affiliates } from 'vtex.affiliates'
-
+import type { Affiliates } from '../typings/affiliates'
 import { findDocumentsByField } from '../utils/shared'
 
 type Props = {

--- a/node/resolvers/getAffiliateStoreName.ts
+++ b/node/resolvers/getAffiliateStoreName.ts
@@ -1,5 +1,4 @@
-import type { Affiliates } from 'vtex.affiliates'
-
+import type { Affiliates } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 
 type Props = {

--- a/node/resolvers/isAffiliateValid.ts
+++ b/node/resolvers/isAffiliateValid.ts
@@ -1,5 +1,4 @@
-import type { Affiliates } from 'vtex.affiliates'
-
+import type { Affiliates } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 
 type Props = {

--- a/node/resolvers/updateAffiliate.ts
+++ b/node/resolvers/updateAffiliate.ts
@@ -1,6 +1,7 @@
-import type { Affiliates, MutationUpdateAffiliateArgs } from 'vtex.affiliates'
+import type { MutationUpdateAffiliateArgs } from 'vtex.affiliates'
 import CustomGraphQLError from '@vtex/api/lib/errors/customGraphQLError'
 
+import type { Affiliates } from '../typings/affiliates'
 import { findDocumentsByField, isSlugValid } from '../utils/shared'
 import type { Error } from './pushErrors'
 import { pushErrors } from './pushErrors'

--- a/node/typings/affiliates.ts
+++ b/node/typings/affiliates.ts
@@ -1,3 +1,5 @@
+export type Maybe<T> = T | null
+
 type Address = {
   city?: string
   complement?: string
@@ -36,4 +38,43 @@ export type AffiliateLead = {
 
 export type GetOrderFormInput = {
   orderFormId: string
+}
+
+export interface Affiliates {
+  slug: string
+  name: string
+  storeName?: string
+  email: string
+  phone?: string
+  refId?: string
+  address?: {
+    city?: string
+    complement?: string
+    country?: string
+    neighborhood?: string
+    number?: string
+    postalCode?: string
+    reference?: string
+    state?: string
+    street?: string
+    [k: string]: unknown
+  }
+  document?: string
+  documentType?: string
+  isApproved: boolean
+  marketing?: {
+    instagram?: string
+    whatsapp?: string
+    facebook?: string
+    gtmId?: string
+    [k: string]: unknown
+  }
+  [k: string]: unknown
+}
+
+export interface UserAffiliation {
+  email: string
+  affiliateId?: string
+  affiliateStartDate?: string
+  [k: string]: unknown
 }

--- a/node/utils/withCustomSchema.ts
+++ b/node/utils/withCustomSchema.ts
@@ -1,0 +1,88 @@
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import type { PaginationArgs, WithMetadata } from '@vtex/clients'
+import { MasterDataEntity } from '@vtex/clients'
+
+type ScrollInput<K> = {
+  fields: Array<ThisType<K> | '_all'>
+  sort?: string
+  size?: number
+  mdToken?: string
+}
+
+export const withCustomSchema = <TEntity extends Record<string, unknown>>(
+  schema: string,
+  _MasterdataClient: new (
+    context: IOContext,
+    options?: InstanceOptions
+  ) => MasterDataEntity<TEntity>
+): new (
+  context: IOContext,
+  options?: InstanceOptions
+) => MasterDataEntity<TEntity> => {
+  return class extends MasterDataEntity<TEntity> {
+    public dataEntity: string
+    public schema: string
+    public client: MasterDataEntity<TEntity>
+
+    constructor(ctx: IOContext, options?: InstanceOptions) {
+      super(ctx, options)
+      this.client = new _MasterdataClient(ctx, options)
+      this.dataEntity = this.client.dataEntity
+      this.schema = schema
+      this.client.schema = schema
+    }
+
+    public save(entity: TEntity) {
+      return this.client.save(entity)
+    }
+
+    public update(id: string, fields: Partial<TEntity>) {
+      return this.client.update(id, fields)
+    }
+
+    public saveOrUpdate(fields: TEntity & { id: string }) {
+      return this.client.saveOrUpdate(fields)
+    }
+
+    public delete(id: string) {
+      return this.client.delete(id)
+    }
+
+    // These es-lint disables are needed because I have to extend the class and its methods surpass the max params.
+    // eslint-disable-next-line max-params
+    public search<K extends keyof WithMetadata<TEntity>>(
+      pagination: PaginationArgs,
+      fields: Array<ThisType<K> | '_all'>,
+      sort?: string,
+      where?: string
+    ): Promise<Array<Pick<WithMetadata<TEntity>, K>>> {
+      return this.client.search(pagination, fields, sort, where)
+    }
+
+    // eslint-disable-next-line max-params
+    public searchRaw<K extends keyof WithMetadata<TEntity>>(
+      pagination: PaginationArgs,
+      fields: Array<ThisType<K> | '_all'>,
+      sort?: string,
+      where?: string
+    ): Promise<{
+      data: Array<Pick<WithMetadata<TEntity>, K>>
+      pagination: { total: number; page: number; pageSize: number }
+    }> {
+      return this.client.searchRaw(pagination, fields, sort, where)
+    }
+
+    public get<K extends keyof WithMetadata<TEntity>>(
+      id: string,
+      fields: Array<ThisType<K> | '_all'>
+    ) {
+      return this.client.get(id, fields)
+    }
+
+    public async scroll<K extends keyof WithMetadata<TEntity>>(
+      input: ScrollInput<K>
+    ) {
+      return this.client.scroll(input)
+    }
+  }
+}

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1658,10 +1658,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.22":
-  version "6.45.22"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
-  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
+"@vtex/api@6.45.24":
+  version "6.45.24"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.24.tgz#5643d80de9b5ac9491c03a47be0329872896a6eb"
+  integrity sha512-BaNdncM2Jfqdu/DikxrDVH7fdek5vH02nvH4RCyNcZ3KSSYZaKk4QGr2EjEHI/rhkOIbJOlOAW5ol4uDcGbQjQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -5709,7 +5709,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex.affiliates",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "scripts": {
     "test": "vtex-test-tools test --collectCoverage"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Since there is no intention to change the affiliates schemas from now on, we are setting s fixed schema for the Master Data client to work with, not using the Master Data Builder anymore, since there is a lot of indexation problems related to it

Since the last schema version created by the Builder based on our most recent structure is the 1.7.0, everyone that updates the app for this or newer versions will use the last schema generated.

#### What problem is this solving?

- Builder Hub Flow

#### How to test it?

- Access the benesonb2b on gabrielbarrosaffonso workspace

#### Screenshots or example usage

I created an example app to test if this new function that returns the MD Client works.
Based on the tests, even when a new version exists, it stills use the fixed schema defined to create a new document :) 

<img width="1729" alt="image" src="https://github.com/vtex/affiliates/assets/53904010/1668c67d-7771-49e7-9b55-fe876516d414">

<img width="1733" alt="image" src="https://github.com/vtex/affiliates/assets/53904010/f8fc0082-b825-4149-8f6e-69164a8783e5">

<img width="1774" alt="image" src="https://github.com/vtex/affiliates/assets/53904010/1a092215-578d-4e9c-a9fd-eff497201bd4">

<img width="1707" alt="image" src="https://github.com/vtex/affiliates/assets/53904010/23fb1c54-a396-490c-9eaa-230f146760cb">


#### How does this PR make you feel? [:link:]()

![](https://media.giphy.com/media/xT5LMHB9KDyfLE2eTC/giphy.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
