### PR TITLE
AddAffiliates query authentication fix

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -7,7 +7,7 @@ type Query {
     filter: AffiliatesFilterInput
     sorting: AffliatesSortingInput
   ): AffiliatesPage! @checkAdminAccess
-  getAffiliate(affiliateId: ID!): Affiliate @checkAdminAccess
+  getAffiliate(affiliateId: ID!): Affiliate @checkUserAccess
   getAffiliateByEmail(email: String!): Affiliate
   getAffiliatesScroll(
     filter: AffiliatesFilterInput
@@ -16,7 +16,7 @@ type Query {
 }
 
 type Mutation {
-  addAffiliate(newAffiliate: NewAffiliateInput!): Affiliate! @checkAdminAccess
+  addAffiliate(newAffiliate: NewAffiliateInput!): Affiliate!
   updateAffiliate(
     affiliateId: String!
     updateAffiliate: UpdateAffiliateInput!

--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,7 @@
     "@types/jest": "^27.0.2",
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.45.22",
+    "@vtex/api": "6.45.24",
     "@vtex/test-tools": "^3.4.1",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1658,10 +1658,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
   integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
-"@vtex/api@6.45.22":
-  version "6.45.22"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.22.tgz#fa9bbfde1a4d4fbbaf6cce9f6dbc9bb9ee929ba3"
-  integrity sha512-g5cGUDhF4FADgSMpQmce/bnIZumwGlPG2cabwbQKIQ+cCFMZqOEM/n+YQb1+S8bCyHkzW3u/ZABoyCKi5/nxxg==
+"@vtex/api@6.45.24":
+  version "6.45.24"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.24.tgz#5643d80de9b5ac9491c03a47be0329872896a6eb"
+  integrity sha512-BaNdncM2Jfqdu/DikxrDVH7fdek5vH02nvH4RCyNcZ3KSSYZaKk4QGr2EjEHI/rhkOIbJOlOAW5ol4uDcGbQjQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Our clients were having problems with the addAffiliates query on the storefront because of the new authentication that was based on the adminAuthToken, since everyone should have the possibility to create a new affiliate, I'm deleting the directive from this query

#### What problem is this solving?

- Affiliates can now be added again on the storefront

#### How to test it?

- You can access the workspace below:
https://affiliatescookiefix--sandboxbrdev.myvtex.com/affiliate/form

#### Screenshots or example usage

https://github.com/vtex/affiliates/assets/53904010/3f0c76db-c65c-4120-a025-db88dac1998d

https://github.com/vtex/affiliates/assets/53904010/b1024c7e-0aac-4c4a-992b-8795847dcd09


#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/H3DbAtQ4liPuM/giphy.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
