### PR TITLE
Increase timeout to GraphQL

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -36,7 +36,7 @@ import { fieldResolvers } from './resolvers/fieldResolvers'
 import { getAffiliateByEmail } from './resolvers/getAffiliateByEmail'
 import { schemaDirectives } from './directives'
 
-const TIMEOUT_MS = 1000
+const TIMEOUT_MS = 30000
 
 // This is the configuration for clients available in `ctx.clients`.
 const clients: ClientsConfig<Clients> = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

The affiliate search is receiving a timeout due to the number of records in the table. To fix this it will be necessary to increase this timeout

#### What problem is this solving?

It is correcting the timeout in the affiliate filter

#### How to test it?

[Tela:](https://trackfield.myvtex.com/admin/affiliates-management)


![image](https://github.com/vtex/affiliates/assets/5565933/94b6a450-fb1b-4ec2-a976-41f330d97ede)



#### Screenshots or example usage


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
